### PR TITLE
Fix/remove unneeded shuttle task

### DIFF
--- a/deploy-prod-shuttle.yml
+++ b/deploy-prod-shuttle.yml
@@ -34,7 +34,7 @@
         git pull origin {{tag}}
         make all
 
-- name: Shuttle Server Deployment
+- name: Shuttle Servers Deployment
   remote_user: root
   hosts: shuttle_servers
   tasks:


### PR DESCRIPTION
Removing redundant tasks since the initial task for shuttle 6 would loop through all shuttle_servers from the inventory file.